### PR TITLE
lanzatool: perform secure assembling for lanzaboote_image and PE wrapping

### DIFF
--- a/nix/lanzaboote.nix
+++ b/nix/lanzaboote.nix
@@ -33,6 +33,9 @@ in
   };
 
   config = mkIf cfg.enable {
+    # bootspec is putting at false
+    # until we fix this upstream, we will mkForce it.
+    boot.loader.supportsInitrdSecrets = mkForce true;
     boot.loader.external = {
       enable = true;
       passBootspec = true;


### PR DESCRIPTION
reduces the amount of TOCTOU we are having.

cc @nikstur @blitz 